### PR TITLE
fix name of the language in the langs list returned by linguist function

### DIFF
--- a/ghlinguist/__init__.py
+++ b/ghlinguist/__init__.py
@@ -34,7 +34,7 @@ def linguist(
         L = line.split()
         if not L:  # EOF
             break
-        lpct.append((L[0], L[-1]))
+        lpct.append((L[-1], L[0][:-1]))
 
     if rtype:
         return lpct[0][0]

--- a/ghlinguist/__init__.py
+++ b/ghlinguist/__init__.py
@@ -8,18 +8,24 @@ EXE = shutil.which("github-linguist")
 GIT = shutil.which("git")
 
 
-def linguist(path: Path, rtype: bool = False) -> Union[str, List[Tuple[str, str]]]:
+def linguist(
+    path: Path, rtype: bool = False
+) -> Union[str, List[Tuple[str, str]]]:
     """runs Github Linguist Ruby script"""
 
     if not EXE:
-        raise ImportError("GitHub Linguist not found, did you install it per README?")
+        raise ImportError(
+            "GitHub Linguist not found, did you install it per README?"
+        )
 
     path = Path(path).expanduser()
 
     if not checkrepo(path):
         return None
 
-    ret = subprocess.check_output([EXE, str(path)], universal_newlines=True).split("\n")
+    ret = subprocess.check_output(
+        [EXE, str(path)], universal_newlines=True
+    ).split("\n")
 
     # %% parse percentage
     lpct = []
@@ -28,7 +34,7 @@ def linguist(path: Path, rtype: bool = False) -> Union[str, List[Tuple[str, str]
         L = line.split()
         if not L:  # EOF
             break
-        lpct.append((L[1], L[0][:-1]))
+        lpct.append((L[0], L[-1]))
 
     if rtype:
         return lpct[0][0]
@@ -45,11 +51,15 @@ def checkrepo(path: Path) -> bool:
     path = Path(path).expanduser()
 
     if not (path / ".git").is_dir():
-        logging.error(f'{path} does not seem to be a Git repository, and Linguist only works on files after "git commit"')
+        logging.error(
+            f'{path} does not seem to be a Git repository, and Linguist only works on files after "git commit"'
+        )
         return False
 
     # %% detect uncommited (dirty)
-    ret = subprocess.check_output([GIT, "status", "--porcelain"], cwd=path, universal_newlines=True)
+    ret = subprocess.check_output(
+        [GIT, "status", "--porcelain"], cwd=path, universal_newlines=True
+    )
 
     ADD = {"A", "?"}
     MOD = "M"
@@ -60,7 +70,9 @@ def checkrepo(path: Path) -> bool:
             continue
 
         if ADD.intersection(L[0]) or (MOD in L[0] and L[1] == ".gitattributes"):
-            logging.warning(f' {path} has uncommited changes: \n\n{ret}\n Linguist only works on files after "git commit"')
+            logging.warning(
+                f' {path} has uncommited changes: \n\n{ret}\n Linguist only works on files after "git commit"'
+            )
             return False
 
     return True


### PR DESCRIPTION
This commit PR fix the output of ghlinguist.

Before :
```ghlinguist                      
496905 91.91%
24312 4.50%
13284 2.46%
3996 0.74%
1451 0.27%
```

after : 
```ghlinguist
Go 91.91%
Assembly 4.50%
Python 2.46%
Makefile 0.74%
Dockerfile 0.27%
Shell 0.13%
```